### PR TITLE
Feat(NOISSUE): Query LogSeq for outdated pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of various helper scripts that I use.
 * [Send reminder for pull requests that need review](pr_review/README.md)
 * [Search subreddits for specific string](search_reddit/README.md)
 * [Pip list for requirement files](pip_list_for_requirement_files/README.md)
+* [Query LogSeq for outdated pages](query_logsec_for_outdated_pages/README.md)
 
 Note: Have a look at the README files in the specific subdirectories for documentation.
 

--- a/query_logsec_for_outdated_pages/README.md
+++ b/query_logsec_for_outdated_pages/README.md
@@ -1,0 +1,48 @@
+# Identify outdated pages in LogSeq
+
+This script generates a LogSeq page with links to pages that have not been edited within a specified number of days. It helps you identify pages in your LogSeq graph that may need attention or updating.
+
+## Use Cases
+
+You might find this script useful if you want to periodically review and clean up outdated pages in your LogSeq graph. It provides a centralized list of pages that haven't been edited recently, making it easier to prioritize updates.
+
+## Requirements
+
+- Python 3
+
+## Usage
+
+The script can be run from the command line. It requires specifying the path to your LogSeq graph directory and the number of days to consider a page outdated.
+
+```sh
+python3 generate_outdated_pages.py --logseq_path /path/to/your/logseq/graph --days_threshold 30
+```
+
+## Arguments
+
+- `--logseq_path` (required): Path to your LogSeq graph directory.
+- `--days_threshold` (required): Number of days to consider a page outdated.
+
+## Output
+
+The script generates a markdown file (`outdated-pages.md`) in your LogSeq graph directory. This file contains links to pages that have not been edited in the specified number of days.
+
+Each entry in the output file includes:
+
+- A link to the outdated page.
+- The date and time when the page was last edited.
+
+## Example Output
+
+Here's an example of what the `outdated-pages.md` file might look like:
+
+```markdown
+# Pages not edited in the last 30 days
+
+- [[Page1]] - last edited at 2024-06-10 08:30:00
+- [[Page2]] - last edited at 2024-06-05 14:00:00
+```
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../LICENSE) file for details.

--- a/query_logsec_for_outdated_pages/query_logsec_for_outdated_pages.py
+++ b/query_logsec_for_outdated_pages/query_logsec_for_outdated_pages.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+"""
+A script to create a page that links to outdated pages that are not edited
+for $X amount of days in your LogSeq graph
+"""
+
+import os
+import datetime
+import re
+import argparse
+
+# Set up command-line argument parsing
+parser = argparse.ArgumentParser(description='Generate a LogSeq page with links to outdated pages.')
+parser.add_argument('--logseq_path', type=str, help='Path to your LogSeq graph')
+parser.add_argument('--days_threshold', type=int, help='Number of days to consider a page outdated')
+
+args = parser.parse_args()
+logseq_path = args.logseq_path
+days_threshold = args.days_threshold
+
+# Regex pattern to exclude pages that start with a date in:
+# YYYY-MM-DD, YYYY_MM_DD, or journals_YYYY_MM_DD format
+exclude_pattern = re.compile(r'^(journals_)?\d{4}[-_]\d{2}[-_]\d{2}.*$')
+
+# Get current date
+now = datetime.datetime.now()
+
+# Find all pages
+pages = []
+for root, dirs, files in os.walk(logseq_path):
+    for file in files:
+        if file.endswith(".md"):
+            file_path = os.path.join(root, file)
+            page_name = os.path.basename(file).replace(".md", "")
+            # Exclude pages matching the specific pattern
+            if exclude_pattern.match(page_name):
+                continue
+            modification_time = os.path.getmtime(file_path)
+            modification_date = datetime.datetime.fromtimestamp(modification_time)
+            # Check if the page has not been modified in the specified number of days
+            if (now - modification_date).days > days_threshold:
+                pages.append((page_name, modification_date))
+
+# Generate a LogSeq page with links to outdated pages
+output_path = os.path.join(logseq_path, "outdated-pages.md")
+with open(output_path, "w", encoding='utf-8') as f:
+    f.write(f"# Pages not edited in the last {days_threshold} days\n")
+    for page_name, mod_date in pages:
+        f.write(f"- [[{page_name}]] - last edited at {mod_date.strftime('%Y-%m-%d %H:%M:%S')}\n")
+
+print(f"Generated {output_path} with {len(pages)} outdated pages.")


### PR DESCRIPTION
This script generates a LogSeq page with links to pages not edited within a specified number of days. It helps you identify pages in your LogSeq graph that need attention or updating.